### PR TITLE
Bug fix auc spline

### DIFF
--- a/R/auc.R
+++ b/R/auc.R
@@ -76,7 +76,7 @@ function(x, y, from = min(x), to = max(x), type=c("linear", "spline"), absolutea
 
     } else {
         if (absolutearea)
-            myfunction <- function(x) { abs(splinefun(x, y, method="natural")) }
+            myfunction <- function(z) { abs(splinefun(x, y, method="natural")(z)) }
         else
             myfunction <- splinefun(x, y, method="natural")
 


### PR DESCRIPTION
Bug fix to correct the specification in myfunction in the auc function when type is spline and absolutearea is true.

See https://stackoverflow.com/questions/47866598/error-lengths-differ-when-trying-to-integrate-but-lengths-are-the-same/